### PR TITLE
Draft of alchemical free energy calculation example 

### DIFF
--- a/alchemical-free-energy/README.md
+++ b/alchemical-free-energy/README.md
@@ -82,7 +82,8 @@ for k in range(nstates):
             context.setParameter('lambda', lambdas[l])
             u_kln[k,l,iteration] = context.getState(getEnergy=True).getPotentialEnergy() / kT
 ```
-Finally, the [multistate Bennett acceptance ratio (MBAR)](https://dx.doi.org/10.1063%2F1.2978177) is used on decorrelated samples to estimate the free energy of annihilating the particle using the conda-installable [`pymbar`](http://pymbar.org/) package:
+Finally, the [multistate Bennett acceptance ratio (MBAR)](https://dx.doi.org/10.1063%2F1.2978177) is used to estimate the free energy of annihilating the particle using the conda-installable [`pymbar`](http://pymbar.org/) package.
+In order to estimate how much data must be discarded to equilibration, we use a scheme for [automated equilibration detection](http://dx.doi.org/10.1021/acs.jctc.5b00784) and subsequent extraction of decorrelated samples found in the [`pymbar.timeseries`](http://github.com/choderalab/pymbar) module.
 ```python
 # Estimate free energy of Lennard-Jones particle insertion
 from pymbar import MBAR, timeseries

--- a/alchemical-free-energy/README.md
+++ b/alchemical-free-energy/README.md
@@ -1,7 +1,14 @@
 # Alchemical free energy example
 
-OpenMM's powerful Custom Force facilities allow a great deal of flexibility in representing
+OpenMM's custom forces---which allow the programmer to express a potential algebraically, potentially with multiple parameters that can be adjusted on the fly---allow a great deal of flexibility and simplicity in encoding potentials while still achieving high performance on GPUs.
+One common use of this facility is to convert standard interactions (such as Lennard-Jones potentials) into alchemically-modified potentials for the purposes of computing free energy differences.
+The alchemical free energy code [YANK](http://github.com/choderalab/yank), for example, uses a variety of custom forces to represent alchemically-modified potentials for [protein-ligand alchemical binding free energy calculations](http://dx.doi.org/10.1007/s10822-013-9689-8).
+
+As a simple example of how this is facilitated by custom forces, consider computing the chemical potential of liquid argon by estimating the free energy of inserting a Lennard-Jones particle 
 
 ```python
+from si
+# Create a Lennard-Jones fluid
+system = openmm
 
 ```

--- a/alchemical-free-energy/README.md
+++ b/alchemical-free-energy/README.md
@@ -83,7 +83,7 @@ for k in range(nstates):
             u_kln[k,l,iteration] = context.getState(getEnergy=True).getPotentialEnergy() / kT
 ```
 Finally, the [multistate Bennett acceptance ratio (MBAR)](https://dx.doi.org/10.1063%2F1.2978177) is used on decorrelated samples to estimate the free energy of annihilating the particle using the conda-installable [`pymbar`](http://pymbar.org/) package:
-```
+```python
 # Estimate free energy of Lennard-Jones particle insertion
 from pymbar import MBAR, timeseries
 # Subsample data to extract uncorrelated equilibrium timeseries

--- a/alchemical-free-energy/README.md
+++ b/alchemical-free-energy/README.md
@@ -4,11 +4,95 @@ OpenMM's custom forces---which allow the programmer to express a potential algeb
 One common use of this facility is to convert standard interactions (such as Lennard-Jones potentials) into alchemically-modified potentials for the purposes of computing free energy differences.
 The alchemical free energy code [YANK](http://github.com/choderalab/yank), for example, uses a variety of custom forces to represent alchemically-modified potentials for [protein-ligand alchemical binding free energy calculations](http://dx.doi.org/10.1007/s10822-013-9689-8).
 
-As a simple example of how this is facilitated by custom forces, consider computing the chemical potential of liquid argon by estimating the free energy of inserting a Lennard-Jones particle 
-
+As a simple example of how this is facilitated by custom forces, consider computing the chemical potential of liquid argon by estimating the free energy of alchemically annihilating a Lennard-Jones particle.
+First, we create a simple Lennard-Jones fluid to represent liquid argon at 120 K and 80 atm, which can be conveniently done using the `testsystems` module of the conda-installable [`openmmtools`](http://github.com/choderalab/openmmtools) package:
 ```python
-from si
-# Create a Lennard-Jones fluid
-system = openmm
+from simtk import openmm, unit
 
+# Create a Lennard-Jones fluid
+pressure = 80*unit.atmospheres
+temperature = 120*unit.kelvin
+collision_rate = 5/unit.picoseconds
+timestep = 5*unit.femtoseconds
+from openmmtools.testsystems import LennardJonesFluid
+sigma = 3.4*unit.angstrom; epsilon = 0.238 * unit.kilocalories_per_mole
+fluid = LennardJonesFluid(sigma=sigma, epsilon=epsilon)
+[system, positions] = [fluid.system, fluid.positions]
+
+# Add a barostat
+barostat = openmm.MonteCarloBarostat(pressure, temperature)
+system.addForce(barostat)
 ```
+To allow one of the Lennard-Jones particles to be alchemically eliminated, we create a [`CustomNonbondedForce`](http://docs.openmm.org/7.1.0/api-python/generated/simtk.openmm.openmm.CustomNonbondedForce.html#simtk.openmm.openmm.CustomNonbondedForce) that will compute the interactions between the alchemical particle and the remaining chemical particles using a [softcore potential](http://dx.doi.org/10.1016/0009-2614(94)00397-1).
+The alchemically-modified particle has its Lennard-Jones well depth (`epsilon` parameter) set to zero in `NonbondedForce`, while the `CustomNonbondedForce` is set to evaluate only the interactions between the alchemically-modified particle and the remaining particles using [`addInteractionGroup()`](http://docs.openmm.org/7.1.0/api-python/generated/simtk.openmm.openmm.CustomNonbondedForce.html#simtk.openmm.openmm.CustomNonbondedForce.addInteractionGroup) to specify only interactions between these groups are to be computed.
+A global context parameter `lambda` is created to control the coupling of the alchemically-modified particle with the rest of the system during the simulation.
+```python
+# Retrieve the NonbondedForce
+forces = { force.__class__.__name__ : force for force in system.getForces() }
+nbforce = forces['NonbondedForce']
+
+# Add a CustomNonbondedForce to handle only alchemically-modified interactions
+alchemical_particles = set([0])
+chemical_particles = set(range(system.getNumParticles())) - alchemical_particles
+energy_function = 'lambda*4*epsilon*x*(x-1.0); x = (sigma/reff_sterics)^6;'
+energy_function += 'reff_sterics = sigma*(0.5*(1.0-lambda) + (r/sigma)^6)^(1/6);'
+custom_force = openmm.CustomNonbondedForce(energy_function)
+custom_force.addGlobalParameter('lambda', 1.0)
+custom_force.addGlobalParameter('sigma', sigma)
+custom_force.addGlobalParameter('epsilon', epsilon)
+for index in range(system.getNumParticles()):
+    [charge, sigma, epsilon] = nbforce.getParticleParameters(index)
+    custom_force.addParticle([])
+    if index in alchemical_particles:
+        nbforce.setParticleParameters(index, charge*0, sigma, epsilon*0)
+custom_force.addInteractionGroup(alchemical_particles, chemical_particles)
+system.addForce(custom_force)
+```
+We then create a [`LangevinIntegrator`](http://docs.openmm.org/7.1.0/api-python/generated/simtk.openmm.openmm.LangevinIntegrator.html#simtk.openmm.openmm.LangevinIntegrator) and [`Context`](http://docs.openmm.org/7.1.0/api-python/generated/simtk.openmm.openmm.Context.html#simtk.openmm.openmm.Context) to run the simulation, and run a series of simulations at different values of `lambda`:
+````python
+# Create a context
+integrator = openmm.LangevinIntegrator(temperature, collision_rate, timestep)
+context = openmm.Context(system, integrator)
+context.setPositions(positions)
+
+# Minimize energy
+print('Minimizing energy...')
+openmm.LocalEnergyMinimizer.minimize(context)
+
+# Collect data
+nsteps = 500 # number of steps per sample
+niterations = 50 # number of samples to collect per alchemical state
+import numpy as np
+lambdas = np.linspace(1.0, 0.0, 10) # alchemical lambda schedule
+nstates = len(lambdas)
+u_kln = np.zeros([nstates,nstates,niterations], np.float64)
+kT = unit.AVOGADRO_CONSTANT_NA * unit.BOLTZMANN_CONSTANT_kB * integrator.getTemperature()
+for k in range(nstates):
+    for iteration in range(niterations):
+        print('state %5d iteration %5d / %5d' % (k, iteration, niterations))
+        # Set alchemical state
+        context.setParameter('lambda', lambdas[k])
+        # Run some dynamics
+        integrator.step(nsteps)
+        # Compute energies at all alchemical states
+        for l in range(nstates):
+            context.setParameter('lambda', lambdas[l])
+            u_kln[k,l,iteration] = context.getState(getEnergy=True).getPotentialEnergy() / kT
+```
+Finally, the [multistate Bennett acceptance ratio (MBAR)](https://dx.doi.org/10.1063%2F1.2978177) is used on decorrelated samples to estimate the free energy of annihilating the particle using the conda-installable [`pymbar`](http://pymbar.org/) package:
+```
+# Estimate free energy of Lennard-Jones particle insertion
+from pymbar import MBAR, timeseries
+# Subsample data to extract uncorrelated equilibrium timeseries
+N_k = np.zeros([nstates], np.int32) # number of uncorrelated samples
+for k in range(nstates):
+    [nequil, g, Neff_max] = timeseries.detectEquilibration(u_kln[k,k,:])
+    indices = timeseries.subsampleCorrelatedData(u_kln[k,k,:], g=g)
+    N_k[k] = len(indices)
+    u_kln[k,:,0:N_k[k]] = u_kln[k,:,indices]
+# Compute free energy differences and statistical uncertainties
+mbar = MBAR(u_kln, N_k)
+[DeltaF_ij, dDeltaF_ij, Theta_ij] = mbar.getFreeEnergyDifferences()
+```
+A downloadable version of this example is available at on [github](https://github.com/choderalab/openmm7tutorials/blob/master/alchemical-free-energy).
+A more fully featured toolkit for re-encoding standard OpenMM forces as alchemically-modified custom forces is available via the conda-installable [`alchemy`](https://github.com/choderalab/alchemy) package.

--- a/alchemical-free-energy/README.md
+++ b/alchemical-free-energy/README.md
@@ -1,0 +1,7 @@
+# Alchemical free energy example
+
+OpenMM's powerful Custom Force facilities allow a great deal of flexibility in representing
+
+```python
+
+```

--- a/alchemical-free-energy/alchemical-example.py
+++ b/alchemical-free-energy/alchemical-example.py
@@ -2,10 +2,18 @@ from simtk import openmm, unit
 import numpy as np
 
 # Create a Lennard-Jones fluid
+pressure = 80*unit.atmospheres
+temperature = 120*unit.kelvin
+collision_rate = 5/unit.picoseconds
+timestep = 5*unit.femtoseconds
 from openmmtools.testsystems import LennardJonesFluid
 sigma = 3.4*unit.angstrom; epsilon = 0.238 * unit.kilocalories_per_mole
 fluid = LennardJonesFluid(sigma=sigma, epsilon=epsilon)
 [system, positions] = [fluid.system, fluid.positions]
+
+# Add a barostat
+barostat = openmm.MonteCarloBarostat(pressure, temperature)
+system.addForce(barostat)
 
 # Retrieve the NonbondedForce
 forces = { force.__class__.__name__ : force for force in system.getForces() }
@@ -29,7 +37,7 @@ custom_force.addInteractionGroup(alchemical_particles, chemical_particles)
 system.addForce(custom_force)
 
 # Create a context
-integrator = openmm.LangevinIntegrator(300*unit.kelvin, 5/unit.picoseconds, 5*unit.femtoseconds)
+integrator = openmm.LangevinIntegrator(temperature, collision_rate, timestep)
 context = openmm.Context(system, integrator)
 context.setPositions(positions)
 

--- a/alchemical-free-energy/alchemical-example.py
+++ b/alchemical-free-energy/alchemical-example.py
@@ -1,5 +1,4 @@
 from simtk import openmm, unit
-import numpy as np
 
 # Create a Lennard-Jones fluid
 pressure = 80*unit.atmospheres
@@ -48,6 +47,7 @@ openmm.LocalEnergyMinimizer.minimize(context)
 # Collect data
 nsteps = 500 # number of steps per sample
 niterations = 50 # number of samples to collect per alchemical state
+import numpy as np
 lambdas = np.linspace(1.0, 0.0, 10) # alchemical lambda schedule
 nstates = len(lambdas)
 u_kln = np.zeros([nstates,nstates,niterations], np.float64)

--- a/alchemical-free-energy/alchemical-example.py
+++ b/alchemical-free-energy/alchemical-example.py
@@ -23,13 +23,14 @@ alchemical_particles = set([0])
 chemical_particles = set(range(system.getNumParticles())) - alchemical_particles
 energy_function = 'lambda*4*epsilon*x*(x-1.0); x = (sigma/reff_sterics)^6;'
 energy_function += 'reff_sterics = sigma*(0.5*(1.0-lambda) + (r/sigma)^6)^(1/6);'
+energy_function += 'sigma = 0.5*(sigma1+sigma2); epsilon = sqrt(epsilon1*epsilon2);'
 custom_force = openmm.CustomNonbondedForce(energy_function)
 custom_force.addGlobalParameter('lambda', 1.0)
-custom_force.addGlobalParameter('sigma', sigma)
-custom_force.addGlobalParameter('epsilon', epsilon)
+custom_force.addPerParticleParameter('sigma')
+custom_force.addPerParticleParameter('epsilon')
 for index in range(system.getNumParticles()):
     [charge, sigma, epsilon] = nbforce.getParticleParameters(index)
-    custom_force.addParticle([])
+    custom_force.addParticle([sigma, epsilon])
     if index in alchemical_particles:
         nbforce.setParticleParameters(index, charge*0, sigma, epsilon*0)
 custom_force.addInteractionGroup(alchemical_particles, chemical_particles)

--- a/alchemical-free-energy/alchemical-example.py
+++ b/alchemical-free-energy/alchemical-example.py
@@ -4,7 +4,7 @@ from simtk import openmm, unit
 pressure = 80*unit.atmospheres
 temperature = 120*unit.kelvin
 collision_rate = 5/unit.picoseconds
-timestep = 5*unit.femtoseconds
+timestep = 2.5*unit.femtoseconds
 from openmmtools.testsystems import LennardJonesFluid
 sigma = 3.4*unit.angstrom; epsilon = 0.238 * unit.kilocalories_per_mole
 fluid = LennardJonesFluid(sigma=sigma, epsilon=epsilon)
@@ -46,7 +46,7 @@ print('Minimizing energy...')
 openmm.LocalEnergyMinimizer.minimize(context)
 
 # Collect data
-nsteps = 500 # number of steps per sample
+nsteps = 2500 # number of steps per sample
 niterations = 50 # number of samples to collect per alchemical state
 import numpy as np
 lambdas = np.linspace(1.0, 0.0, 10) # alchemical lambda schedule
@@ -73,10 +73,11 @@ for k in range(nstates):
     [nequil, g, Neff_max] = timeseries.detectEquilibration(u_kln[k,k,:])
     indices = timeseries.subsampleCorrelatedData(u_kln[k,k,:], g=g)
     N_k[k] = len(indices)
-    u_kln[k,:,0:N_k[k]] = u_kln[k,:,indices]
+    u_kln[k,:,0:N_k[k]] = u_kln[k,:,indices].T
 # Compute free energy differences and statistical uncertainties
 mbar = MBAR(u_kln, N_k)
 [DeltaF_ij, dDeltaF_ij, Theta_ij] = mbar.getFreeEnergyDifferences()
+
 print('DeltaF_ij (kT):')
 print(DeltaF_ij)
 print('dDeltaF_ij (kT):')

--- a/alchemical-free-energy/alchemical-example.py
+++ b/alchemical-free-energy/alchemical-example.py
@@ -1,0 +1,74 @@
+from simtk import openmm, unit
+import numpy as np
+
+# Create a Lennard-Jones fluid
+from openmmtools.testsystems import LennardJonesFluid
+sigma = 3.4*unit.angstrom; epsilon = 0.238 * unit.kilocalories_per_mole
+fluid = LennardJonesFluid(sigma=sigma, epsilon=epsilon)
+[system, positions] = [fluid.system, fluid.positions]
+
+# Retrieve the NonbondedForce
+forces = { force.__class__.__name__ : force for force in system.getForces() }
+nbforce = forces['NonbondedForce']
+
+# Add a CustomNonbondedForce to handle only alchemically-modified interactions
+alchemical_particles = set([0])
+chemical_particles = set(range(system.getNumParticles())) - alchemical_particles
+energy_function = 'lambda*4*epsilon*x*(x-1.0); x = (sigma/reff_sterics)^6;'
+energy_function += 'reff_sterics = sigma*(0.5*(1.0-lambda) + (r/sigma)^6)^(1/6);'
+custom_force = openmm.CustomNonbondedForce(energy_function)
+custom_force.addGlobalParameter('lambda', 1.0)
+custom_force.addGlobalParameter('sigma', sigma)
+custom_force.addGlobalParameter('epsilon', epsilon)
+for index in range(system.getNumParticles()):
+    [charge, sigma, epsilon] = nbforce.getParticleParameters(index)
+    custom_force.addParticle([])
+    if index in alchemical_particles:
+        nbforce.setParticleParameters(index, charge*0, sigma, epsilon*0)
+custom_force.addInteractionGroup(alchemical_particles, chemical_particles)
+system.addForce(custom_force)
+
+# Create a context
+integrator = openmm.LangevinIntegrator(300*unit.kelvin, 5/unit.picoseconds, 5*unit.femtoseconds)
+context = openmm.Context(system, integrator)
+context.setPositions(positions)
+
+# Minimize energy
+print('Minimizing energy...')
+openmm.LocalEnergyMinimizer.minimize(context)
+
+# Collect data
+nsteps = 500 # number of steps per sample
+niterations = 50 # number of samples to collect per alchemical state
+lambdas = np.linspace(1.0, 0.0, 10) # alchemical lambda schedule
+nstates = len(lambdas)
+u_kln = np.zeros([nstates,nstates,niterations], np.float64)
+kT = unit.AVOGADRO_CONSTANT_NA * unit.BOLTZMANN_CONSTANT_kB * integrator.getTemperature()
+for k in range(nstates):
+    for iteration in range(niterations):
+        print('state %5d iteration %5d / %5d' % (k, iteration, niterations))
+        # Set alchemical state
+        context.setParameter('lambda', lambdas[k])
+        # Run some dynamics
+        integrator.step(nsteps)
+        # Compute energies at all alchemical states
+        for l in range(nstates):
+            context.setParameter('lambda', lambdas[l])
+            u_kln[k,l,iteration] = context.getState(getEnergy=True).getPotentialEnergy() / kT
+
+# Estimate free energy of Lennard-Jones particle insertion
+from pymbar import MBAR, timeseries
+# Subsample data to extract uncorrelated equilibrium timeseries
+N_k = np.zeros([nstates], np.int32) # number of uncorrelated samples
+for k in range(nstates):
+    [nequil, g, Neff_max] = timeseries.detectEquilibration(u_kln[k,k,:])
+    indices = timeseries.subsampleCorrelatedData(u_kln[k,k,:], g=g)
+    N_k[k] = len(indices)
+    u_kln[k,:,0:N_k[k]] = u_kln[k,:,indices]
+# Compute free energy differences and statistical uncertainties
+mbar = MBAR(u_kln, N_k)
+[DeltaF_ij, dDeltaF_ij, Theta_ij] = mbar.getFreeEnergyDifferences()
+print('DeltaF_ij (kT):')
+print(DeltaF_ij)
+print('dDeltaF_ij (kT):')
+print(dDeltaF_ij)


### PR DESCRIPTION
This example illustrates the computation of the chemical potential of liquid argon using alchemical free energy methods.

See [README.md](https://github.com/choderalab/openmm7tutorials/blob/d0aaa853eac4d4320f6f83ea50644b6c3a79f7d6/alchemical-free-energy/README.md).